### PR TITLE
Fixes #26 plugin crash

### DIFF
--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -1,6 +1,9 @@
 name: Continuous Integration
 
-on: [push, pull_request]
+on:
+  pull_request:
+    branches:    
+      - main
 
 jobs:
   build:
@@ -8,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        build_configuration: [Release, Debug]
+        build_configuration: [Release]
         build_platform: [x64, x86]
 
     steps:
@@ -33,13 +36,13 @@ jobs:
       if: matrix.build_platform == 'x64' && matrix.build_configuration == 'Release'
       uses: actions/upload-artifact@v3
       with:
-          name: nppRandomStringGenerator.1.5.0.x64
+          name: nppRandomStringGenerator.1.7.1.x64
           path: nppRandomStringGenerator\bin\${{ matrix.build_configuration }}-x64\nppRandomStringGenerator.dll
 
     - name: Archive artifacts for x86
       if: matrix.build_platform == 'x86' && matrix.build_configuration == 'Release'
       uses: actions/upload-artifact@v3
       with:
-          name: nppRandomStringGenerator.1.5.0.x86
+          name: nppRandomStringGenerator.1.7.1.x86
           path: nppRandomStringGenerator\bin\${{ matrix.build_configuration }}\nppRandomStringGenerator.dll
 

--- a/nppRandomStringGenerator/Forms/ConfigAndGenerate.cs
+++ b/nppRandomStringGenerator/Forms/ConfigAndGenerate.cs
@@ -40,7 +40,7 @@ namespace Kbg.NppPluginNET
                 if (ctrl.Name.StartsWith("NumericUpDown"))
                 {
                     NumericUpDown nupdown = ctrl as NumericUpDown;
-                    nupdown.Value = Convert.ToDecimal(configitem.Value);
+                    nupdown.Value = Math.Min(Convert.ToDecimal(configitem.Value), nupdown.Maximum);
                 }
                 if (ctrl.Name.StartsWith("Checkbox"))
                 {

--- a/nppRandomStringGenerator/Properties/AssemblyInfo.cs
+++ b/nppRandomStringGenerator/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.7.1")]
-[assembly: AssemblyFileVersion("1.7.1")]
+[assembly: AssemblyVersion("1.7.2")]
+[assembly: AssemblyFileVersion("1.7.2")]

--- a/nppRandomStringGenerator/Storage/Settings.cs
+++ b/nppRandomStringGenerator/Storage/Settings.cs
@@ -45,7 +45,7 @@ namespace nppRandomStringGenerator.Storage
                 settings = DeserializeIni(FilePath);
 
                 
-                if (settings.Appversion != "1.7.0")
+                if (settings.Appversion != "1.7.2")
                 {
                     SettingsModel defaults = DeserializeIniFromString(Resources.nppRandomStringGeneratorSettings);
 
@@ -57,7 +57,7 @@ namespace nppRandomStringGenerator.Storage
                         }
                     }
                     settings.Appname = "nppRandomStringGenerator";
-                    settings.Appversion = "1.7.0";
+                    settings.Appversion = "1.7.2";
                 }
             }
             catch (Exception ex)

--- a/nppRandomStringGenerator/Storage/nppRandomStringGeneratorSettings.ini
+++ b/nppRandomStringGenerator/Storage/nppRandomStringGeneratorSettings.ini
@@ -1,5 +1,5 @@
 appname=nppRandomStringGenerator
-appversion=1.7.0
+appversion=1.7.2
 NumericUpDownLength=32
 NumericUpDownQuantity=8
 CheckboxNumbers=true


### PR DESCRIPTION
When removing limit from quantity and setting a higher quantity will result in an overflow when reopening the plugin. It will now use the default maximum if the saved quantity is bigger then maximum.